### PR TITLE
submit tags as options for the front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jekyllMatter(input, options); // => output
 
 - `date`  : {Date} - Date object
 - `author`: {String} - author name
+- `tags`: {Array} - strings of tag names for the article
 
 ## Contributing
 

--- a/lib/jekyll-meta-from-markdown.js
+++ b/lib/jekyll-meta-from-markdown.js
@@ -19,6 +19,9 @@ function createFrontMatter(options) {
     } else {
         stack.push('date: ' + (new Date).toISOString());
     }
+    if (options.tags && options.tags instanceof Array) {
+      stack.push("tags:\n  - " + options.tags.join("\n  - "));
+    }
     stack.push('---');
     return  stack.join("\n")
 }

--- a/lib/jekyll-meta-from-markdown.js
+++ b/lib/jekyll-meta-from-markdown.js
@@ -19,7 +19,7 @@ function createFrontMatter(options) {
     } else {
         stack.push('date: ' + (new Date).toISOString());
     }
-    if (options.tags && options.tags instanceof Array) {
+    if (options.tags && Array.isArray(options.tags)) {
       stack.push("tags:\n  - " + options.tags.join("\n  - "));
     }
     stack.push('---');

--- a/test/fixtures/input_tags.markdown
+++ b/test/fixtures/input_tags.markdown
@@ -1,0 +1,6 @@
+# title
+
+test text
+
+* item 1
+* item 2

--- a/test/fixtures/output_tags-out.markdown
+++ b/test/fixtures/output_tags-out.markdown
@@ -1,0 +1,14 @@
+---
+layout: post
+title: "title"
+author: azu
+date: 2014-09-08T21:38:00.000Z
+tags:
+  - sample
+  - test
+---
+
+test text
+
+* item 1
+* item 2

--- a/test/fixtures/output_tags.markdown
+++ b/test/fixtures/output_tags.markdown
@@ -1,0 +1,14 @@
+---
+layout: post
+title: "title"
+author: azu
+date: 2014-09-08T21:38:00.000Z
+tags:
+  - sample
+  - test
+---
+
+test text
+
+* item 1
+* item 2

--- a/test/jekyll-meta-from-markdown-test.js
+++ b/test/jekyll-meta-from-markdown-test.js
@@ -24,4 +24,15 @@ describe("jekyll-meta-from-markdown-test", function () {
             });
         });
     });
+    describe("when options has tags", function () {
+        var input = fs.readFileSync(__dirname + "/fixtures/input_tags.markdown", "utf-8");
+        var output = fs.readFileSync(__dirname + "/fixtures/output_tags.markdown", "utf-8");
+        it("should return text contain jekyll front matter", function () {
+            assert.equal(jekyllMatter(input, {
+                author: "azu",
+                date: new Date("2014-09-08T21:38"),
+                tags: ["sample", "test"]
+            }), output);
+        });
+    });
 });


### PR DESCRIPTION
Added the ability to provide an array of tags for the given file to be added as front matter. Useful for when reading in file names or directory structures a file is apart of.

Sample:

```javascript
jekyllMatter(input, {
  author: "azu",
  date: new Date("2014-09-08T21:38"),
  tags: ["sample", "test"]
})
```

outputs:

```md
---
layout: post
title: "title"
author: azu
date: 2014-09-08T21:38:00.000Z
tags:
  - sample
  - test
---
```